### PR TITLE
added pagination

### DIFF
--- a/src/app/[id]/page.tsx
+++ b/src/app/[id]/page.tsx
@@ -2,11 +2,10 @@ import { getComment, getStory } from "@/services/hn";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-export default async function Home({ params }:{ params: { id:number }}) {
+export default async function Home({ params }: { params: { id: number } }) {
   const story = await getStory(params.id);
 
-  if (!story)
-    return notFound();
+  if (!story) return notFound();
 
   const url = story.url ? new URL(story.url) : null;
   const comments = story.kids ? await Promise.all(story.kids?.map(getComment)) : await Promise.resolve([]);
@@ -15,18 +14,18 @@ export default async function Home({ params }:{ params: { id:number }}) {
     <main>
       <div className="leading-none mb-10">
         <h1 className="block font-bold visited:text-slate-500 text-2xl">{story.title}</h1>
-        <div className="text-xs text-slate-700">{url?.host ? `${url?.host} - ` : ''} <Link href={`/${story.id}`}>{story.score} poäng</Link> - <Link href={`/${story.id}`}>{story.descendants || 'Inga'} kommentarer</Link> - {Math.floor(Date.now()/1000 - story.time)} sekunder sedan</div>
+        <div className="text-xs text-slate-700">{url?.host ? `${url?.host} - ` : ''} <Link href={`/${story.id}`}>{story.score} poäng</Link> - <Link href={`/${story.id}`}>{story.descendants || 'Inga'} kommentarer</Link> - {Math.floor(Date.now() / 1000 - story.time)} sekunder sedan</div>
       </div>
-      { story.text && <div className="mb-10" dangerouslySetInnerHTML={{__html: story.text}} /> }
+      {story.text && <div className="mb-10" dangerouslySetInnerHTML={{ __html: story.text }} />}
       <div className="text-lg font-bold">Kommentarer ({comments.length})</div>
       <ul className="mb-10">
-        { comments.map(comment => (
+        {comments.map(comment => (
           <li className="mb-10" key={comment?.id}>
-            <div className="text-sm text-slate-700 italic">{comment?.by} - {Math.floor(Date.now()/1000 - comment?.time)} sekunder sedan</div>
+            <div className="text-sm text-slate-700 italic">{comment?.by} - {Math.floor(Date.now() / 1000 - comment?.time)} sekunder sedan</div>
             <div dangerouslySetInnerHTML={{ __html: comment?.text || '' }} />
           </li>
-        )) }
+        ))}
       </ul>
     </main>
   );
-}
+};

--- a/src/app/_components/Pagination.tsx
+++ b/src/app/_components/Pagination.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import React from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+// Components
+import PaginationButton from './PaginationButton';
+
+type Props = {
+  totalPages: number;
+}
+
+export default function Pagination({ totalPages }: Props) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentPage = Number(searchParams.get('page')) || 1;
+
+  const createPageURL = (pageNumber: number | string) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('page', pageNumber.toString());
+    return `${pathname}?${params.toString()}`;
+  };
+
+  return (
+    <div className="flex items-center justify-between my-4">
+      <PaginationButton
+        href={createPageURL(currentPage - 1)}
+        direction='back'
+        isDisabled={currentPage <= 1}
+      />
+      <span className="select-none">{currentPage} / {totalPages}</span>
+      <PaginationButton
+        href={createPageURL(currentPage + 1)}
+        direction='forward'
+        isDisabled={currentPage >= totalPages}
+      />
+    </div>
+  );
+};

--- a/src/app/_components/PaginationButton.tsx
+++ b/src/app/_components/PaginationButton.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import React from 'react';
+import Link from 'next/link';
+
+type Props = {
+  href: string;
+  direction: "back" | "forward";
+  isDisabled: boolean;
+}
+
+export default function PaginationButton({ href, direction, isDisabled }: Props) {
+  return (
+    <Link
+      href={href}
+      role="button"
+      className={`${isDisabled ? 'pointer-events-none text-gray-300' : ''} flex items-center justify-center rounded w-8 h-8 bg-gray-400 select-none`}
+    >
+      <span>
+        {direction === "back" ? "<" : ">"}
+      </span>
+    </Link>
+  );
+};

--- a/src/app/_components/PaginationButton.tsx
+++ b/src/app/_components/PaginationButton.tsx
@@ -13,6 +13,7 @@ export default function PaginationButton({ href, direction, isDisabled }: Props)
   return (
     <Link
       href={href}
+      aria-label={direction === "back" ? "previous page" : "next page"}
       role="button"
       className={`${isDisabled ? 'pointer-events-none text-gray-300' : ''} flex items-center justify-center rounded w-8 h-8 bg-gray-400 select-none`}
     >

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,9 +20,7 @@ export default function RootLayout({
             <Image src="/logo.webp" className="h-16 w-16 mr-5 inline-block" alt="Nördnytt logga" width={100} height={100} />
             Nördnytt! 🤓
           </a>
-          
           {children}
-
           <div className="bg-slate-200 text-slate-600 p-2 text-sm">
             <p>Alla inlägg kommer från <a target="_blank" href="https://news.ycombinator.com">HackerNews</a>.</p>
           </div>
@@ -30,4 +28,4 @@ export default function RootLayout({
       </body>
     </html>
   );
-}
+};

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 
 export default function NotFound() {
   const r = useRouter();
   return (
     <main>
       <p className="mb-10">Kunde inte hitta sidan. <a className="cursor-pointer underline" onClick={() => r.back()}>Gå tillbaka</a></p>
-      <img src="/404.webp" className="scale-150 origin-top"/>
+      <Image src="/404.webp" className="scale-150 origin-top" alt="Not found bild" />
     </main>
   );
-}
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,46 @@
 import { getTopStories } from "@/services/hn";
 import Link from "next/link";
+// Components
+import Pagination from "./_components/Pagination";
 
-export default async function Home() {
-  const topstories = await getTopStories();
+const STORIES_PER_PAGE = 10;
+
+type Props = {
+  searchParams?: { page: string };
+}
+
+export default async function Home({ searchParams }: Props) {
+  const currentPage = Number(searchParams?.page) || 1;
+  const paginatedStories = await getTopStories((currentPage - 1) * STORIES_PER_PAGE, STORIES_PER_PAGE);
+  const totalPages = paginatedStories.totalStories / STORIES_PER_PAGE;
 
   return (
     <main>
-      { topstories.map((story, index) => {
+      {paginatedStories.topstories.map((story, index) => {
         const url = story.url ? new URL(story.url) : null;
 
         return (
           <div className="leading-none mb-4" key={story.id}>
-            <a title={story.title} href={story.url || `/${story.id}`} target={url?.host ? "_blank" : ""} className="pb-1 whitespace-nowrap text-ellipsis overflow-hidden block font-bold visited:text-slate-500">{index+1}. {story.title}</a>
-            <div className="text-xs text-slate-700">{url?.host ? `${url?.host} - ` : ''} <Link href={`/${story.id}`}>{story.score} poäng - {story.descendants || 'Inga'} kommentarer - {Math.floor(Date.now()/1000 - story.time)} sekunder sedan</Link></div>
+            <div className="leading-none mb-4" key={story.id}>
+              <a
+                title={story.title}
+                href={story.url || `/${story.id}`}
+                target={url?.host ? "_blank" : ""}
+                className="pb-1 whitespace-nowrap text-ellipsis overflow-hidden block font-bold visited:text-slate-500">
+                {index + 1 + ((currentPage - 1) * STORIES_PER_PAGE)}. {story.title}
+              </a>
+              <div className="text-xs text-slate-700">
+                {url?.host ? `${url?.host} - ` : ''}
+                <Link href={`/${story.id}`}>
+                  {story.score} poäng - {story.descendants || 'Inga'} kommentarer - {Math.floor(Date.now() / 1000 - story.time)}
+                  sekunder sedan
+                </Link>
+              </div>
+            </div>
           </div>
         )
-      }) }
+      })}
+      <Pagination totalPages={totalPages} />
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ type Props = {
 export default async function Home({ searchParams }: Props) {
   const currentPage = Number(searchParams?.page) || 1;
   const paginatedStories = await getTopStories((currentPage - 1) * STORIES_PER_PAGE, STORIES_PER_PAGE);
-  const totalPages = paginatedStories.totalStories / STORIES_PER_PAGE;
+  const totalPages = Math.ceil(paginatedStories.totalStories / STORIES_PER_PAGE);
 
   return (
     <main>

--- a/src/services/hn.ts
+++ b/src/services/hn.ts
@@ -1,33 +1,43 @@
-import { Comment, Story } from "@/types";
+import { Comment, Story } from '@/types';
 
-export const getTopStories = async ():Promise<Story[]> => {
-  const topstories:number[] = await fetch("https://hacker-news.firebaseio.com/v0/topstories.json", {
+export const getTopStories = async (
+  offset: number,
+  limit: number
+): Promise<{ topstories: Story[]; totalStories: number }> => {
+  const topstories: number[] = await fetch('https://hacker-news.firebaseio.com/v0/topstories.json', {
     next: {
       revalidate: 120
     }
   }).then(res => res.json());
-  
-  return Promise.all(topstories.splice(0, 10).map(id => fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`, {
-    next: {
-      revalidate: 120
-    }
-  }).then(res => res.json())))
-}
 
-export const getStory = async (id:number):Promise<Story> => {
+  const paginatedTopStories = await Promise.all(
+    topstories.splice(offset, limit).map(id =>
+      fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`, {
+        next: {
+          revalidate: 120
+        }
+      }).then(res => res.json())
+    )
+  );
+
+  return {
+    topstories: paginatedTopStories,
+    totalStories: topstories.length
+  };
+};
+
+export const getStory = async (id: number): Promise<Story> => {
   return await fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`, {
     next: {
       revalidate: 120
     }
-  })
-    .then(res => res.json());
-}
+  }).then(res => res.json());
+};
 
-export const getComment = async (id:number):Promise<Comment> => {
+export const getComment = async (id: number): Promise<Comment> => {
   return await fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`, {
     next: {
       revalidate: 120
     }
-  })
-    .then(res => res.json());
-}
+  }).then(res => res.json());
+};


### PR DESCRIPTION
I selected the task of implementing pagination. 

Pagination is often better than for example an infinity scroll regarding SEO. If I would have made an infinity scroll I would probably have created it on the client with Tanstack-Query instead. I've done that many times with great success.
For example, I have such an infinity scroll on this old site: https://react-movie-db-v4.vercel.app/
This is a site that is from one of my first React course many years ago where the students build a movie application.

I'm using searchParams to keep track of the pages as it's better for SEO also and you can jump directly to a page that way.

This task was completed in roughly 45 minutes so there's of course more that could be done polishing it. I haven't focused on making any design so there are bare buttons to navigate and showing the current/total page(s)

One thing that could be an improvement is to not load all the stories at once. Instead loading them with the offset and limit. I  haven't checked the API now but I guess it has that functionality. But I didn't want to mess with your fetch functions right now as it felt as it was out of scope for this task.

Have a great weekend!